### PR TITLE
Add micromamba environment and dependency checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,39 @@
 
 you will need to create a conda/minimanba environment and start from there. all dependencies shall be installed via minimanba or conda.
 
+### Quick Start
+
+Install [micromamba](https://mamba.readthedocs.io/en/latest/user_guide/micromamba.html) and create the environment:
+
+```
+micromamba env create -f environment.yml
+micromamba activate mesh-env
+```
+
+The `environment.yml` specifies the core dependencies used by this project:
+
+- `openvdb` – sparse voxel and distance field processing
+- `pcl` – point cloud utilities
+- `cgal-cpp` – computational geometry algorithms
+- `igl` – libigl geometry processing bindings
+- `open3d` – visualization and Python helpers
+- `pymeshlab` – additional mesh filters
+- `pytest` – test runner
+
+All packages are sourced from the `conda-forge` channel and installed without superuser privileges.
+
+### Pipeline Demo
+
+A minimal end-to-end pipeline is provided in `recon/src/pipeline.cpp`. It leverages PCL for point cloud preprocessing, OpenVDB for level-set construction and dual contouring, CGAL for surface metrics, and libigl for mesh export. Compile and run:
+
+```
+g++ recon/src/pipeline.cpp -std=c++17 $(pkg-config --cflags --libs openvdb) $(pcl_config --cflags) $(pcl_config --libs) $(pkg-config --cflags --libs cgal) -o pipeline
+./pipeline input.ply output.obj
+```
+
+The Python wrapper `recon/scripts/pipeline.py` invokes the binary and loads the resulting mesh using Open3D and PyMeshLab for verification.
+
+
 
 ---
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,15 @@
+name: mesh-env
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - openvdb
+  - pcl
+  - cgal-cpp
+  - igl
+  - open3d
+  - pymeshlab
+  - pytest
+  - pkg-config
+  - cmake
+  - eigen

--- a/recon/scripts/pipeline.py
+++ b/recon/scripts/pipeline.py
@@ -1,0 +1,33 @@
+"""Simple wrapper around the C++ reconstruction pipeline.
+
+It demonstrates how the compiled binary can be invoked from Python and
+uses Open3D and PyMeshLab to load the resulting mesh so the environment
+covering all dependencies is exercised.
+"""
+
+import argparse
+import subprocess
+import open3d as o3d
+import pymeshlab
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Point cloud to mesh pipeline")
+    parser.add_argument("point_cloud", help="Input PLY point cloud")
+    parser.add_argument("mesh", help="Output OBJ mesh path")
+    parser.add_argument("--binary", default="pipeline", help="Path to compiled C++ binary")
+    args = parser.parse_args()
+
+    subprocess.check_call([args.binary, args.point_cloud, args.mesh])
+
+    mesh = o3d.io.read_triangle_mesh(args.mesh)
+    print(f"Open3D loaded mesh with {len(mesh.vertices)} vertices and {len(mesh.triangles)} faces")
+
+    ms = pymeshlab.MeshSet()
+    ms.load_new_mesh(args.mesh)
+    current = ms.current_mesh()
+    print(f"PyMeshLab reports {current.vertex_number()} vertices and {current.face_number()} faces")
+
+
+if __name__ == "__main__":
+    main()

--- a/recon/src/pipeline.cpp
+++ b/recon/src/pipeline.cpp
@@ -1,0 +1,112 @@
+#include <openvdb/openvdb.h>
+#include <openvdb/tools/ParticlesToLevelSet.h>
+#include <openvdb/tools/VolumeToMesh.h>
+#include <pcl/io/ply_io.h>
+#include <pcl/point_types.h>
+#include <pcl/filters/statistical_outlier_removal.h>
+#include <pcl/features/normal_3d.h>
+#include <pcl/search/kdtree.h>
+#include <CGAL/Simple_cartesian.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Polygon_mesh_processing/area.h>
+#include <igl/writeOBJ.h>
+#include <Eigen/Core>
+#include <vector>
+#include <string>
+#include <iostream>
+
+// Simple particle list wrapper around PCL point cloud
+struct PointList {
+    using value_type = openvdb::Vec3R;
+    std::vector<value_type> pts;
+    size_t size() const { return pts.size(); }
+    void getPos(size_t i, value_type& xyz) const { xyz = pts[i]; }
+};
+
+int main(int argc, char** argv) {
+    if (argc < 3) {
+        std::cerr << "Usage: " << argv[0] << " input.ply output.obj" << std::endl;
+        return 1;
+    }
+    std::string in = argv[1];
+    std::string out = argv[2];
+
+    // Load point cloud via PCL
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>());
+    if (pcl::io::loadPLYFile(in, *cloud) != 0) {
+        std::cerr << "Failed to load point cloud: " << in << std::endl;
+        return 1;
+    }
+
+    // Outlier removal
+    pcl::StatisticalOutlierRemoval<pcl::PointXYZ> sor;
+    sor.setInputCloud(cloud);
+    sor.setMeanK(8);
+    sor.setStddevMulThresh(1.0);
+    sor.filter(*cloud);
+
+    // Normal estimation
+    pcl::NormalEstimation<pcl::PointXYZ, pcl::Normal> ne;
+    pcl::search::KdTree<pcl::PointXYZ>::Ptr tree(new pcl::search::KdTree<pcl::PointXYZ>());
+    ne.setInputCloud(cloud);
+    ne.setSearchMethod(tree);
+    ne.setKSearch(16);
+    pcl::PointCloud<pcl::Normal>::Ptr normals(new pcl::PointCloud<pcl::Normal>());
+    ne.compute(*normals);
+
+    // Convert to OpenVDB level set
+    openvdb::initialize();
+    using GridT = openvdb::FloatGrid;
+    openvdb::math::Transform::Ptr transform = openvdb::math::Transform::createLinearTransform(0.05);
+    GridT::Ptr grid = GridT::create(3.0);
+    grid->setTransform(transform);
+
+    PointList plist;
+    plist.pts.reserve(cloud->size());
+    for (const auto& p : cloud->points) {
+        plist.pts.emplace_back(p.x, p.y, p.z);
+    }
+    openvdb::tools::ParticlesToLevelSet<GridT> raster(*grid);
+    raster.setRmin(0.02);
+    raster.rasterizeSpheres(plist);
+    raster.finalize();
+
+    // Dual contouring to mesh
+    std::vector<openvdb::Vec3s> verts;
+    std::vector<openvdb::Vec3I> tris;
+    openvdb::tools::volumeToMesh(*grid, verts, tris);
+
+    // Save mesh using libigl
+    Eigen::MatrixXd V(verts.size(), 3);
+    Eigen::MatrixXi F(tris.size(), 3);
+    for (size_t i = 0; i < verts.size(); ++i) {
+        V(i, 0) = verts[i].x();
+        V(i, 1) = verts[i].y();
+        V(i, 2) = verts[i].z();
+    }
+    for (size_t i = 0; i < tris.size(); ++i) {
+        F(i, 0) = tris[i].x();
+        F(i, 1) = tris[i].y();
+        F(i, 2) = tris[i].z();
+    }
+    if (!igl::writeOBJ(out, V, F)) {
+        std::cerr << "Failed to write OBJ: " << out << std::endl;
+        return 1;
+    }
+
+    // Load mesh into CGAL and compute area for validation
+    typedef CGAL::Simple_cartesian<double> K;
+    typedef CGAL::Surface_mesh<K::Point_3> SurfaceMesh;
+    SurfaceMesh mesh;
+    for (const auto& v : verts) {
+        mesh.add_vertex(K::Point_3(v.x(), v.y(), v.z()));
+    }
+    for (const auto& t : tris) {
+        mesh.add_face(SurfaceMesh::Vertex_index(t.x()), SurfaceMesh::Vertex_index(t.y()), SurfaceMesh::Vertex_index(t.z()));
+    }
+    double area = CGAL::Polygon_mesh_processing::area(mesh);
+    std::cout << "Pipeline complete: " << mesh.number_of_vertices() << " vertices, "
+              << mesh.number_of_faces() << " faces, area=" << area << std::endl;
+    return 0;
+}
+

--- a/tests/test_cpp_build.py
+++ b/tests/test_cpp_build.py
@@ -1,0 +1,60 @@
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+def test_cpp_compilation(tmp_path):
+    """Compile and run a tiny C++ program using core libraries.
+
+    The program prints the library versions so success is obvious in the
+    test logs. We assert that the expected identifiers appear in the
+    output for robustness.
+    """
+
+    code = textwrap.dedent(
+        """
+        #include <openvdb/version.h>
+        #include <pcl/point_cloud.h>
+        #include <CGAL/version.h>
+        #include <iostream>
+        int main() {
+            std::cout << "OpenVDB " << OPENVDB_LIBRARY_VERSION_STRING << std::endl;
+            std::cout << "PCL " << PCL_VERSION_PRETTY << std::endl;
+            std::cout << "CGAL " << CGAL_VERSION_STR << std::endl;
+            return 0;
+        }
+        """
+    )
+    src = tmp_path / "check.cpp"
+    src.write_text(code)
+    conda_prefix = os.environ["CONDA_PREFIX"]
+    include_dir = Path(conda_prefix, "include")
+    pcl_include = next(include_dir.glob("pcl-*/"), None)
+    compile_cmd = [
+        "g++",
+        str(src),
+        "-std=c++17",
+        f"-I{include_dir}",
+        f"-I{include_dir/'eigen3'}",
+    ]
+    if pcl_include:
+        compile_cmd.append(f"-I{pcl_include}")
+    compile_cmd += [
+        f"-L{conda_prefix}/lib",
+        "-o",
+        str(tmp_path / "check"),
+    ]
+    compile_proc = subprocess.run(
+        compile_cmd, capture_output=True, text=True
+    )
+    assert compile_proc.returncode == 0, compile_proc.stderr
+
+    run_proc = subprocess.run(
+        [str(tmp_path / "check")], capture_output=True, text=True
+    )
+    assert run_proc.returncode == 0, run_proc.stderr
+    print(run_proc.stdout.strip())
+    assert "OpenVDB" in run_proc.stdout
+    assert "PCL" in run_proc.stdout
+    assert "CGAL" in run_proc.stdout

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,0 +1,15 @@
+"""Verify that required Python packages can be imported.
+
+The test prints the resolved version for each package so success or
+failure can be easily inspected when running ``pytest -s``.
+"""
+
+import importlib
+
+
+def test_python_packages():
+    modules = ["openvdb", "open3d", "pymeshlab", "igl"]
+    for name in modules:
+        mod = importlib.import_module(name)
+        version = getattr(mod, "__version__", "unknown")
+        print(f"{name} OK (version: {version})")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,65 @@
+import os
+import subprocess
+from pathlib import Path
+
+import open3d as o3d
+import pymeshlab
+
+
+def compile_pipeline(src: Path, exe: Path) -> None:
+    conda_prefix = os.environ["CONDA_PREFIX"]
+    include_dir = Path(conda_prefix, "include")
+
+    # Flags from pkg-config and pcl_config for robust builds
+    openvdb_flags = subprocess.check_output([
+        "pkg-config", "--cflags", "--libs", "openvdb"
+    ], text=True).split()
+
+    try:
+        pcl_cflags = subprocess.check_output(["pcl_config", "--cflags"], text=True).split()
+        pcl_libs = subprocess.check_output(["pcl_config", "--libs"], text=True).split()
+    except Exception:
+        pcl_cflags = []
+        pcl_libs = [
+            "-lpcl_io", "-lpcl_common", "-lpcl_filters", "-lpcl_kdtree",
+            "-lpcl_search", "-lpcl_features",
+        ]
+
+    try:
+        cgal_flags = subprocess.check_output([
+            "pkg-config", "--cflags", "--libs", "cgal"
+        ], text=True).split()
+    except Exception:
+        cgal_flags = ["-lCGAL", "-lgmp", "-lmpfr"]
+
+    compile_cmd = [
+        "g++", str(src), "-std=c++17",
+        f"-I{include_dir}", f"-I{include_dir/'eigen3'}",
+    ] + openvdb_flags + pcl_cflags + cgal_flags + [
+        f"-L{conda_prefix}/lib",
+    ] + pcl_libs + ["-o", str(exe)]
+
+    subprocess.run(compile_cmd, check=True)
+
+
+def test_full_pipeline(tmp_path):
+    src = Path("recon/src/pipeline.cpp")
+    exe = tmp_path / "pipeline"
+    compile_pipeline(src, exe)
+
+    # Generate a simple sphere point cloud using Open3D
+    pcd = o3d.geometry.TriangleMesh.create_sphere(radius=1.0).sample_points_poisson_disk(500)
+    ply_path = tmp_path / "points.ply"
+    o3d.io.write_point_cloud(str(ply_path), pcd)
+
+    out_mesh = tmp_path / "mesh.obj"
+    run_proc = subprocess.run([str(exe), str(ply_path), str(out_mesh)], capture_output=True, text=True)
+    assert run_proc.returncode == 0, run_proc.stderr
+    print(run_proc.stdout.strip())
+
+    ms = pymeshlab.MeshSet()
+    ms.load_new_mesh(str(out_mesh))
+    mesh = ms.current_mesh()
+    print(f"Resulting mesh: {mesh.vertex_number()} vertices, {mesh.face_number()} faces")
+    assert mesh.vertex_number() > 0
+    assert mesh.face_number() > 0


### PR DESCRIPTION
## Summary
- document micromamba-based setup and dependencies
- provide environment.yml for conda-forge packages
- add tests verifying Python imports and C++ compilation of core libs with printed versions
- implement end-to-end point cloud to mesh pipeline and wrap with Python helper
- add integration test compiling and running the pipeline on a synthetic point cloud

## Testing
- `/tmp/bin/micromamba run -n mesh-env pytest -q` *(fails: The given prefix does not exist: "/root/.local/share/mamba/envs/mesh-env")*


------
https://chatgpt.com/codex/tasks/task_e_689a588d14a88333a048ca3bbe2ab6ae