### PR TITLE
feat: add mesh fusion stage

### DIFF
--- a/recon/src/detail_reconstruction.cpp
+++ b/recon/src/detail_reconstruction.cpp
@@ -1,0 +1,493 @@
+#include "detail_reconstruction.h"
+
+#include <pcl/filters/fast_bilateral.h>
+#include <pcl/surface/mls.h>
+#include <pcl/surface/poisson.h>
+#include <pcl/surface/wlop.h>
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/common/geometry.h>
+#include <pcl/common/centroid.h>
+#include <pcl/console/time.h>
+
+#include <igl/signed_distance.h>
+
+#include <map>
+#include <set>
+#include <queue>
+#include <cmath>
+
+#include <Eigen/Dense>
+#include <chrono>
+
+#include <CGAL/Simple_cartesian.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Polygon_mesh_processing/remove_self_intersections.h>
+#include <CGAL/Polygon_mesh_processing/remove_degenerate_faces.h>
+
+namespace recon {
+
+using Kernel = CGAL::Simple_cartesian<double>;
+using SurfaceMesh = CGAL::Surface_mesh<Kernel::Point_3>;
+
+DetailReconstructor::DetailReconstructor(const DetailReconstructionConfig& config)
+    : config_(config) {}
+
+DetailReconstructor::~DetailReconstructor() = default;
+
+bool DetailReconstructor::reconstructDetails(const pcl::PolygonMesh& shell_mesh,
+                                             const PointCloudT::Ptr& original_cloud,
+                                             pcl::PolygonMesh& detail_mesh) {
+    stats_ = Statistics{};
+    if (!original_cloud) return false;
+    stats_.original_points = static_cast<int>(original_cloud->size());
+
+    PointCloudT::Ptr band_points(new PointCloudT);
+    if (!extractOffsetBandPoints(shell_mesh, original_cloud, band_points) ||
+        band_points->empty()) {
+        std::cerr << "细节偏移带点提取失败或为空" << std::endl;
+        return false;
+    }
+    stats_.extracted_points = static_cast<int>(band_points->size());
+
+    PointCloudT::Ptr filtered(new PointCloudT);
+    if (config_.enable_denoising) {
+        if (!denoisePoints(band_points, filtered)) {
+            std::cerr << "去噪失败" << std::endl;
+            return false;
+        }
+        stats_.denoised_points = static_cast<int>(filtered->size());
+    } else {
+        filtered = band_points;
+        stats_.denoised_points = static_cast<int>(filtered->size());
+    }
+
+    computeAdaptiveParameters(filtered);
+
+    bool ok = false;
+    auto start = std::chrono::high_resolution_clock::now();
+    switch (config_.primary_method) {
+        case DetailMethod::GP3:
+            ok = reconstructWithGP3(filtered, detail_mesh);
+            break;
+        case DetailMethod::RIMLS:
+            ok = reconstructWithRIMLs(filtered, detail_mesh);
+            break;
+        case DetailMethod::POISSON:
+            ok = reconstructWithPoisson(filtered, detail_mesh);
+            break;
+    }
+    if (!ok) return false;
+    auto end = std::chrono::high_resolution_clock::now();
+    stats_.reconstruction_time =
+        std::chrono::duration<double>(end - start).count();
+    stats_.output_vertices = static_cast<int>(detail_mesh.cloud.width);
+    stats_.output_triangles = static_cast<int>(detail_mesh.polygons.size());
+
+    start = std::chrono::high_resolution_clock::now();
+    postProcessMesh(detail_mesh);
+    end = std::chrono::high_resolution_clock::now();
+    stats_.post_processing_time =
+        std::chrono::duration<double>(end - start).count();
+
+    return true;
+}
+
+bool DetailReconstructor::extractOffsetBandPoints(const pcl::PolygonMesh& shell_mesh,
+                                                  const PointCloudT::Ptr& original_cloud,
+                                                  PointCloudT::Ptr& extracted) {
+    if (!original_cloud || !extracted) return false;
+
+    pcl::PointCloud<pcl::PointXYZ> shell_pts;
+    pcl::fromPCLPointCloud2(shell_mesh.cloud, shell_pts);
+    Eigen::MatrixXd V(shell_pts.size(), 3);
+    for (size_t i = 0; i < shell_pts.size(); ++i)
+        V.row(i) << shell_pts[i].x, shell_pts[i].y, shell_pts[i].z;
+
+    Eigen::MatrixXi F(shell_mesh.polygons.size(), 3);
+    for (size_t i = 0; i < shell_mesh.polygons.size(); ++i) {
+        const auto& poly = shell_mesh.polygons[i];
+        if (poly.vertices.size() != 3) return false;
+        F.row(i) << poly.vertices[0], poly.vertices[1], poly.vertices[2];
+    }
+
+    Eigen::MatrixXd P(original_cloud->size(), 3);
+    for (size_t i = 0; i < original_cloud->size(); ++i)
+        P.row(i) << (*original_cloud)[i].x, (*original_cloud)[i].y,
+                     (*original_cloud)[i].z;
+
+    Eigen::VectorXd S;
+    igl::signed_distance(P, V, F, igl::SIGNED_DISTANCE_TYPE_WINDING_NUMBER, S);
+
+    extracted->clear();
+    for (size_t i = 0; i < original_cloud->size(); ++i) {
+        double d = S[i];
+        if (std::abs(d) > config_.offset_distance) continue;
+        if (config_.outside_only && d <= 0) continue;
+        extracted->push_back((*original_cloud)[i]);
+    }
+    return true;
+}
+
+bool DetailReconstructor::denoisePoints(const PointCloudT::Ptr& input,
+                                        PointCloudT::Ptr& output) {
+    if (config_.denoising_method == "wlop") {
+        return wlopDenoising(input, output);
+    }
+    if (config_.denoising_method == "bilateral") {
+        return bilateralFilter(input, output);
+    }
+    // 默认使用MLS作为轻度平滑
+    pcl::MovingLeastSquares<PointT, PointT> mls;
+    mls.setInputCloud(input);
+    mls.setSearchRadius(config_.radius_multiplier * 0.03f);
+    mls.setPolynomialFit(true);
+    mls.setComputeNormals(true);
+    mls.process(*output);
+    return true;
+}
+
+bool DetailReconstructor::reconstructWithGP3(const PointCloudT::Ptr& points,
+                                             pcl::PolygonMesh& mesh) {
+    pcl::PointCloud<pcl::PointNormal>::Ptr normals(new pcl::PointCloud<pcl::PointNormal>);
+    pcl::copyPointCloud(*points, *normals);
+
+    pcl::GreedyProjectionTriangulation<pcl::PointNormal> gp3;
+    float search_radius = config_.gp3.edge_length_multiplier * base_radius_;
+    gp3.setSearchRadius(search_radius);
+    gp3.setMu(config_.gp3.mu);
+    gp3.setMaximumNearestNeighbors(config_.gp3.max_nearest_neighbors);
+    gp3.setMaximumAngle(config_.gp3.angle_threshold_planar * M_PI / 180.0f);
+    gp3.setMinimumAngle(config_.gp3.min_angle * M_PI / 180.0f);
+    gp3.setMaximumAngle(config_.gp3.max_angle * M_PI / 180.0f);
+    gp3.setNormalConsistency(config_.gp3.normal_consistency);
+
+    std::vector<pcl::Vertices> triangles;
+    gp3.reconstruct(*normals, triangles);
+
+    pcl::toPCLPointCloud2(*points, mesh.cloud);
+    mesh.polygons = triangles;
+    return !mesh.polygons.empty();
+}
+
+bool DetailReconstructor::reconstructWithRIMLs(const PointCloudT::Ptr& points,
+                                               pcl::PolygonMesh& mesh) {
+    pcl::MovingLeastSquares<PointT, PointT> mls;
+    mls.setInputCloud(points);
+    mls.setSearchRadius(config_.rimls.voxel_size * 3.0f);
+    mls.setPolynomialFit(true);
+    mls.setComputeNormals(true);
+    PointCloudT::Ptr smooth(new PointCloudT);
+    mls.process(*smooth);
+
+    pcl::MarchingCubesHoppe<PointT> mc;
+    mc.setInputCloud(smooth);
+    Eigen::Vector4f min_pt, max_pt;
+    pcl::getMinMax3D(*smooth, min_pt, max_pt);
+    Eigen::Vector3i res;
+    res[0] = res[1] = res[2] = static_cast<int>((max_pt - min_pt).maxCoeff() /
+                                                config_.rimls.voxel_size);
+    mc.setGridResolution(res[0], res[1], res[2]);
+    mc.reconstruct(mesh);
+    return !mesh.polygons.empty();
+}
+
+bool DetailReconstructor::reconstructWithPoisson(const PointCloudT::Ptr& points,
+                                                 pcl::PolygonMesh& mesh) {
+    pcl::PointCloud<pcl::PointNormal>::Ptr normals(new pcl::PointCloud<pcl::PointNormal>);
+    pcl::copyPointCloud(*points, *normals);
+
+    pcl::Poisson<pcl::PointNormal> poisson;
+    poisson.setDepth(8);
+    poisson.setInputCloud(normals);
+    poisson.reconstruct(mesh);
+    return !mesh.polygons.empty();
+}
+
+bool DetailReconstructor::postProcessMesh(pcl::PolygonMesh& mesh) {
+    if (config_.post_processing.remove_hanging_edges) {
+        removeHangingEdges(mesh);
+    }
+    if (config_.post_processing.filter_small_components) {
+        if (filterSmallComponents(mesh)) stats_.removed_components++;
+    }
+    if (config_.post_processing.enable_pmp_repair) {
+        repairWithPMP(mesh);
+    }
+    if (config_.post_processing.enable_simplification) {
+        simplifyMesh(mesh);
+    }
+    performQualityControl(mesh);
+    return true;
+}
+
+bool DetailReconstructor::removeHangingEdges(pcl::PolygonMesh& mesh) {
+    std::map<std::pair<uint32_t, uint32_t>, int> edge_count;
+    for (const auto& poly : mesh.polygons) {
+        if (poly.vertices.size() != 3) continue;
+        for (int e = 0; e < 3; ++e) {
+            uint32_t a = poly.vertices[e];
+            uint32_t b = poly.vertices[(e + 1) % 3];
+            if (a > b) std::swap(a, b);
+            edge_count[{a, b}]++;
+        }
+    }
+
+    std::vector<pcl::Vertices> cleaned;
+    cleaned.reserve(mesh.polygons.size());
+    for (const auto& poly : mesh.polygons) {
+        if (poly.vertices.size() != 3) continue;
+        bool keep = true;
+        for (int e = 0; e < 3 && keep; ++e) {
+            uint32_t a = poly.vertices[e];
+            uint32_t b = poly.vertices[(e + 1) % 3];
+            if (a > b) std::swap(a, b);
+            if (edge_count[{a, b}] < 2) keep = false;
+        }
+        if (keep) cleaned.push_back(poly);
+    }
+    mesh.polygons.swap(cleaned);
+    return true;
+}
+
+bool DetailReconstructor::filterSmallComponents(pcl::PolygonMesh& mesh) {
+    const int min_size = config_.post_processing.min_component_size;
+    if (min_size <= 0) return false;
+
+    // Build adjacency
+    std::vector<std::vector<int>> adj(mesh.polygons.size());
+    for (size_t i = 0; i < mesh.polygons.size(); ++i) {
+        const auto& poly_i = mesh.polygons[i];
+        std::set<uint32_t> verts(poly_i.vertices.begin(), poly_i.vertices.end());
+        for (size_t j = i + 1; j < mesh.polygons.size(); ++j) {
+            const auto& poly_j = mesh.polygons[j];
+            int shared = 0;
+            for (auto v : poly_j.vertices) if (verts.count(v)) shared++;
+            if (shared >= 2) {
+                adj[i].push_back(j);
+                adj[j].push_back(i);
+            }
+        }
+    }
+
+    std::vector<int> comp(mesh.polygons.size(), -1);
+    int cid = 0;
+    for (size_t i = 0; i < mesh.polygons.size(); ++i) {
+        if (comp[i] != -1) continue;
+        std::queue<int> q;
+        q.push(i);
+        comp[i] = cid;
+        int count = 0;
+        std::vector<int> members;
+        while (!q.empty()) {
+            int v = q.front(); q.pop();
+            members.push_back(v);
+            count++;
+            for (int nb : adj[v]) if (comp[nb] == -1) { comp[nb] = cid; q.push(nb); }
+        }
+        if (count < min_size) {
+            for (int idx : members) comp[idx] = -2; // mark for removal
+        }
+        cid++;
+    }
+
+    std::vector<pcl::Vertices> filtered_polys;
+    for (size_t i = 0; i < mesh.polygons.size(); ++i) {
+        if (comp[i] >= 0) filtered_polys.push_back(mesh.polygons[i]);
+    }
+    bool removed = filtered_polys.size() != mesh.polygons.size();
+    mesh.polygons.swap(filtered_polys);
+    return removed;
+}
+
+bool DetailReconstructor::repairWithPMP(pcl::PolygonMesh& mesh) {
+    namespace PMP = CGAL::Polygon_mesh_processing;
+    pcl::PointCloud<pcl::PointXYZ> cloud;
+    pcl::fromPCLPointCloud2(mesh.cloud, cloud);
+
+    SurfaceMesh sm;
+    std::vector<SurfaceMesh::Vertex_index> vmap(cloud.size());
+    for (size_t i = 0; i < cloud.size(); ++i) {
+        vmap[i] = sm.add_vertex(Kernel::Point_3(cloud[i].x, cloud[i].y, cloud[i].z));
+    }
+    for (const auto& poly : mesh.polygons) {
+        if (poly.vertices.size() != 3) continue;
+        sm.add_face(vmap[poly.vertices[0]], vmap[poly.vertices[1]],
+                    vmap[poly.vertices[2]]);
+    }
+
+    if (config_.post_processing.fix_self_intersections)
+        PMP::remove_self_intersections(sm);
+    if (config_.post_processing.fix_non_manifold)
+        PMP::remove_degenerate_faces(sm);
+
+    pcl::PointCloud<pcl::PointXYZ> out_cloud;
+    pcl::PolygonMesh out_mesh;
+    for (auto v : sm.vertices()) {
+        const auto& p = sm.point(v);
+        out_cloud.emplace_back(p.x(), p.y(), p.z());
+    }
+    pcl::toPCLPointCloud2(out_cloud, out_mesh.cloud);
+    for (auto f : sm.faces()) {
+        pcl::Vertices tri;
+        for (auto v : CGAL::vertices_around_face(sm.halfedge(f), sm))
+            tri.vertices.push_back(static_cast<uint32_t>(v));
+        out_mesh.polygons.push_back(tri);
+    }
+    mesh.swap(out_mesh);
+    return true;
+}
+
+bool DetailReconstructor::simplifyMesh(pcl::PolygonMesh& mesh) {
+    // Simple voxel-grid based simplification
+    pcl::PointCloud<pcl::PointXYZ> cloud;
+    pcl::fromPCLPointCloud2(mesh.cloud, cloud);
+    pcl::VoxelGrid<pcl::PointXYZ> vg;
+    vg.setLeafSize(config_.rimls.voxel_size, config_.rimls.voxel_size,
+                   config_.rimls.voxel_size);
+    vg.setInputCloud(cloud.makeShared());
+    pcl::PointCloud<pcl::PointXYZ> ds;
+    vg.filter(ds);
+    pcl::toPCLPointCloud2(ds, mesh.cloud);
+    mesh.polygons.clear();
+    return true;
+}
+
+bool DetailReconstructor::performQualityControl(const pcl::PolygonMesh& mesh) {
+    // Basic check: ensure edges are not too long
+    pcl::PointCloud<pcl::PointXYZ> cloud;
+    pcl::fromPCLPointCloud2(mesh.cloud, cloud);
+    for (const auto& poly : mesh.polygons) {
+        if (poly.vertices.size() != 3) continue;
+        const auto& a = cloud[poly.vertices[0]];
+        const auto& b = cloud[poly.vertices[1]];
+        const auto& c = cloud[poly.vertices[2]];
+        double ab = pcl::geometry::distance(a, b);
+        double bc = pcl::geometry::distance(b, c);
+        double ca = pcl::geometry::distance(c, a);
+        if (ab > config_.quality_control.max_edge_length ||
+            bc > config_.quality_control.max_edge_length ||
+            ca > config_.quality_control.max_edge_length)
+            return false;
+    }
+    return true;
+}
+
+float DetailReconstructor::computePointToMeshDistance(const PointT& point,
+                                                      const pcl::PolygonMesh& mesh) {
+    pcl::PointXYZ p(point.x, point.y, point.z);
+    pcl::PointCloud<pcl::PointXYZ> cloud;
+    pcl::fromPCLPointCloud2(mesh.cloud, cloud);
+    double min_d = std::numeric_limits<double>::max();
+    for (const auto& poly : mesh.polygons) {
+        if (poly.vertices.size() != 3) continue;
+        const auto& a = cloud[poly.vertices[0]];
+        const auto& b = cloud[poly.vertices[1]];
+        const auto& c = cloud[poly.vertices[2]];
+        Eigen::Vector3d pa(p.x - a.x, p.y - a.y, p.z - a.z);
+        Eigen::Vector3d pb(p.x - b.x, p.y - b.y, p.z - b.z);
+        Eigen::Vector3d pc(p.x - c.x, p.y - c.y, p.z - c.z);
+        Eigen::Vector3d ab(b.x - a.x, b.y - a.y, b.z - a.z);
+        Eigen::Vector3d ac(c.x - a.x, c.y - a.y, c.z - a.z);
+        Eigen::Vector3d n = ab.cross(ac);
+        double area2 = n.norm();
+        if (area2 < 1e-8) continue;
+        double dist = std::abs(pa.dot(n.normalized()));
+        if (dist < min_d) min_d = dist;
+    }
+    return static_cast<float>(min_d);
+}
+
+bool DetailReconstructor::isPointOutsideShell(const PointT& point,
+                                              const pcl::PolygonMesh& shell_mesh) {
+    pcl::PointCloud<pcl::PointXYZ> shell_pts;
+    pcl::fromPCLPointCloud2(shell_mesh.cloud, shell_pts);
+    Eigen::MatrixXd V(shell_pts.size(), 3);
+    for (size_t i = 0; i < shell_pts.size(); ++i)
+        V.row(i) << shell_pts[i].x, shell_pts[i].y, shell_pts[i].z;
+    Eigen::MatrixXi F(shell_mesh.polygons.size(), 3);
+    for (size_t i = 0; i < shell_mesh.polygons.size(); ++i) {
+        const auto& poly = shell_mesh.polygons[i];
+        if (poly.vertices.size() != 3) return false;
+        F.row(i) << poly.vertices[0], poly.vertices[1], poly.vertices[2];
+    }
+    Eigen::RowVector3d P(point.x, point.y, point.z);
+    double s;
+    igl::signed_distance(P, V, F, igl::SIGNED_DISTANCE_TYPE_WINDING_NUMBER, s);
+    return s > 0;
+}
+
+bool DetailReconstructor::bilateralFilter(const PointCloudT::Ptr& input,
+                                         PointCloudT::Ptr& output) {
+    pcl::FastBilateralFilter<PointT> fb;
+    fb.setSigmaS(config_.radius_multiplier * 0.03f);
+    fb.setSigmaR(0.02f);
+    fb.setInputCloud(input);
+    fb.applyFilter(*output);
+    return true;
+}
+
+bool DetailReconstructor::wlopDenoising(const PointCloudT::Ptr& input,
+                                        PointCloudT::Ptr& output) {
+    pcl::WLOP<PointT, PointT> wlop;
+    wlop.setInputCloud(input);
+    wlop.setSearchRadius(config_.radius_multiplier * 0.05f);
+    wlop.setDensityWeight(0.5f);
+    wlop.process(*output);
+    return true;
+}
+
+void DetailReconstructor::computeAdaptiveParameters(const PointCloudT::Ptr& points) {
+    auto density = computeLocalDensity(points);
+    if (density.empty()) return;
+    std::vector<float> tmp = density;
+    std::nth_element(tmp.begin(), tmp.begin() + tmp.size() / 2, tmp.end());
+    base_radius_ = tmp[tmp.size() / 2];
+}
+
+std::vector<bool> DetailReconstructor::detectPlanarRegions(const PointCloudT::Ptr& points) {
+    const int k = 16;
+    pcl::search::KdTree<PointT> tree;
+    tree.setInputCloud(points);
+    std::vector<bool> planar(points->size(), false);
+    std::vector<int> idx(k);
+    std::vector<float> dist2(k);
+    for (size_t i = 0; i < points->size(); ++i) {
+        tree.nearestKSearch(i, k, idx, dist2);
+        Eigen::Matrix3f cov = Eigen::Matrix3f::Zero();
+        Eigen::Vector3f mean = Eigen::Vector3f::Zero();
+        for (int id : idx) {
+            const auto& p = (*points)[id];
+            Eigen::Vector3f v(p.x, p.y, p.z);
+            mean += v;
+        }
+        mean /= static_cast<float>(k);
+        for (int id : idx) {
+            Eigen::Vector3f v((*points)[id].x, (*points)[id].y, (*points)[id].z);
+            v -= mean;
+            cov += v * v.transpose();
+        }
+        Eigen::SelfAdjointEigenSolver<Eigen::Matrix3f> es(cov);
+        auto vals = es.eigenvalues();
+        float curvature = vals[0] / (vals.sum() + 1e-6f);
+        planar[i] = curvature < 0.01f;
+    }
+    return planar;
+}
+
+std::vector<float> DetailReconstructor::computeLocalDensity(const PointCloudT::Ptr& points) {
+    const int k = 16;
+    pcl::search::KdTree<PointT> tree;
+    tree.setInputCloud(points);
+    std::vector<float> density(points->size(), 0.0f);
+    std::vector<int> idx(k);
+    std::vector<float> dist2(k);
+    for (size_t i = 0; i < points->size(); ++i) {
+        if (tree.nearestKSearch(i, k, idx, dist2) > 0) {
+            density[i] = std::sqrt(dist2.back());
+        }
+    }
+    return density;
+}
+
+} // namespace recon
+

--- a/recon/src/detail_reconstruction.h
+++ b/recon/src/detail_reconstruction.h
@@ -153,6 +153,7 @@ public:
 private:
     DetailReconstructionConfig config_;
     Statistics stats_;
+    float base_radius_ = 0.02f;
     
     /**
      * 从外壳网格提取偏移带内的点

--- a/recon/src/dual_contouring/dual_contouring.cpp
+++ b/recon/src/dual_contouring/dual_contouring.cpp
@@ -1,0 +1,222 @@
+#include "dual_contouring.h"
+#include <openvdb/tools/Gradient.h>
+#include <pcl/kdtree/kdtree_flann.h>
+#include <queue>
+#include <chrono>
+#include <algorithm>
+
+namespace recon {
+
+// ---------------- QEFData ----------------
+void QEFData::addConstraint(const Eigen::Vector3f& point,
+                            const Eigen::Vector3f& normal,
+                            float weight) {
+    Eigen::Vector3f n = normal * weight;
+    A += n * n.transpose();
+    b += n * (n.dot(point));
+    c += weight * weight * (n.dot(point) * n.dot(point));
+    ++num_constraints;
+}
+
+Eigen::Vector3f QEFData::solve(float regularization) const {
+    Eigen::Matrix3f AtA = A + Eigen::Matrix3f::Identity() * regularization;
+    return AtA.ldlt().solve(b);
+}
+
+// ---------------- DualContouringExtractor ----------------
+DualContouringExtractor::DualContouringExtractor(const DualContouringConfig& config)
+    : config_(config) {
+    openvdb::initialize();
+}
+
+DualContouringExtractor::~DualContouringExtractor() = default;
+
+bool DualContouringExtractor::extractSurface(const UDFGridT::Ptr& udf_grid,
+                                             const LabelGridT::Ptr& label_grid,
+                                             const PointCloudT::Ptr& cloud,
+                                             pcl::PolygonMesh& mesh) {
+    if (!udf_grid || !label_grid) return false;
+    auto start = std::chrono::high_resolution_clock::now();
+    cells_.clear(); vertices_.clear(); normals_.clear(); triangles_.clear();
+
+    // Build signed distance field copy
+    UDFGridT::Ptr sdf = udf_grid->deepCopy();
+    auto label_acc = label_grid->getConstAccessor();
+    for (auto iter = sdf->beginValueOn(); iter; ++iter) {
+        openvdb::Coord c = iter.getCoord();
+        int lbl = label_acc.getValue(c);
+        float val = iter.getValue();
+        iter.setValue(lbl == static_cast<int>(Label::INSIDE) ? -val : val);
+    }
+
+    buildDualCells(sdf, label_grid, cloud);
+    generateTriangles(label_grid);
+    buildPCLMesh(mesh);
+
+    auto end = std::chrono::high_resolution_clock::now();
+    stats_.extraction_time = std::chrono::duration<double>(end - start).count();
+    stats_.vertices_generated = static_cast<int>(vertices_.size());
+    stats_.triangles_generated = static_cast<int>(triangles_.size());
+    return true;
+}
+
+void DualContouringExtractor::buildDualCells(const UDFGridT::Ptr& sdf,
+                                             const LabelGridT::Ptr& label_grid,
+                                             const PointCloudT::Ptr& cloud) {
+    auto sdf_acc = sdf->getConstAccessor();
+    auto label_acc = label_grid->getConstAccessor();
+    openvdb::CoordBBox bbox;
+    label_grid->evalActiveVoxelBoundingBox(bbox);
+    pcl::KdTreeFLANN<PointT> tree;
+    if (cloud && !cloud->empty()) tree.setInputCloud(cloud);
+
+    static const openvdb::Coord corner_offset[8] = {
+        {0,0,0},{1,0,0},{0,1,0},{1,1,0},{0,0,1},{1,0,1},{0,1,1},{1,1,1}
+    };
+    static const int edge_corners[12][2] = {
+        {0,1},{1,3},{3,2},{2,0},
+        {4,5},{5,7},{7,6},{6,4},
+        {0,4},{1,5},{2,6},{3,7}
+    };
+
+    for (int z = bbox.min().z(); z < bbox.max().z(); ++z) {
+        for (int y = bbox.min().y(); y < bbox.max().y(); ++y) {
+            for (int x = bbox.min().x(); x < bbox.max().x(); ++x) {
+                openvdb::Coord base(x,y,z);
+                float sdf_vals[8];
+                bool signs[8];
+                bool has_pos=false, has_neg=false;
+                for (int i=0;i<8;++i){
+                    openvdb::Coord c = base + corner_offset[i];
+                    float v = sdf_acc.getValue(c);
+                    sdf_vals[i]=v;
+                    signs[i]=v>=0;
+                    if (signs[i]) has_pos=true; else has_neg=true;
+                }
+                if (!(has_pos && has_neg)) continue; // not intersected
+                DualCell cell; cell.coord=base; cell.has_vertex=false; cell.vertex_index=-1;
+                for(int e=0;e<12;++e){
+                    int a=edge_corners[e][0]; int b=edge_corners[e][1];
+                    if (signs[a]==signs[b]) continue;
+                    float t=computeIntersectionParameter(sdf_vals[a], sdf_vals[b]);
+                    openvdb::Vec3f p1 = sdf->transform().indexToWorld(base+corner_offset[a]);
+                    openvdb::Vec3f p2 = sdf->transform().indexToWorld(base+corner_offset[b]);
+                    openvdb::Vec3f pos = p1 + (p2-p1)*t;
+                    openvdb::Vec3f n = estimateNormal(pos, sdf, cloud);
+                    cell.qef.addConstraint(Eigen::Vector3f(pos.x(),pos.y(),pos.z()),
+                                           Eigen::Vector3f(n.x(),n.y(),n.z()));
+                }
+                cell.vertex_position = solveQEF(cell);
+                cell.has_vertex = true;
+                cell.vertex_index = static_cast<int>(vertices_.size());
+                vertices_.push_back(cell.vertex_position);
+                cells_[base] = cell;
+            }
+        }
+    }
+    stats_.active_cells = static_cast<int>(cells_.size());
+}
+
+openvdb::Vec3f DualContouringExtractor::solveQEF(const DualCell& cell) {
+    if (cell.qef.num_constraints == 0) {
+        openvdb::Vec3f center = cell.coord.asVec3d();
+        center += openvdb::Vec3d(0.5,0.5,0.5);
+        return openvdb::Vec3f(center);
+    }
+    Eigen::Vector3f v = cell.qef.solve(config_.qef_regularization);
+    return openvdb::Vec3f(v.x(), v.y(), v.z());
+}
+
+openvdb::Vec3f DualContouringExtractor::estimateNormal(const openvdb::Vec3f& position,
+                                                       const UDFGridT::Ptr& sdf,
+                                                       const PointCloudT::Ptr& cloud) {
+    openvdb::Vec3f n = computeGradientNormal(position, sdf);
+    if (config_.use_adaptive_normals && cloud && !cloud->empty()) {
+        openvdb::Vec3f nc = estimateNormalFromCloud(position, cloud);
+        if (nc.lengthSqr() > 1e-6f) n = nc;
+    }
+    if (n.lengthSqr() > 0) n.normalize();
+    return n;
+}
+
+openvdb::Vec3f DualContouringExtractor::computeGradientNormal(const openvdb::Vec3f& position,
+                                                              const UDFGridT::Ptr& sdf) {
+    openvdb::Vec3d idx = sdf->transform().worldToIndex(position);
+    openvdb::Coord c = openvdb::Coord::floor(idx);
+    auto acc = sdf->getConstAccessor();
+    float dx1 = acc.getValue(c.offsetBy(1,0,0));
+    float dx0 = acc.getValue(c.offsetBy(-1,0,0));
+    float dy1 = acc.getValue(c.offsetBy(0,1,0));
+    float dy0 = acc.getValue(c.offsetBy(0,-1,0));
+    float dz1 = acc.getValue(c.offsetBy(0,0,1));
+    float dz0 = acc.getValue(c.offsetBy(0,0,-1));
+    return openvdb::Vec3f((dx1-dx0)/2.0f, (dy1-dy0)/2.0f, (dz1-dz0)/2.0f);
+}
+
+openvdb::Vec3f DualContouringExtractor::estimateNormalFromCloud(const openvdb::Vec3f& position,
+                                                                const PointCloudT::Ptr& cloud) {
+    pcl::KdTreeFLANN<PointT> tree;
+    tree.setInputCloud(cloud);
+    PointT q; q.x=position.x(); q.y=position.y(); q.z=position.z();
+    std::vector<int> idx(8); std::vector<float> dist2(8);
+    openvdb::Vec3f n(0.0f);
+    if (tree.nearestKSearch(q,8,idx,dist2)>0){
+        for(int i:idx){
+            const auto& p = cloud->points[i];
+            n += openvdb::Vec3f(p.normal_x,p.normal_y,p.normal_z);
+        }
+    }
+    return n;
+}
+
+float DualContouringExtractor::computeIntersectionParameter(float v1, float v2){
+    return v1 / (v1 - v2);
+}
+
+void DualContouringExtractor::generateTriangles(const LabelGridT::Ptr& label_grid){
+    static const openvdb::Coord neighbors[3] = { {1,0,0},{0,1,0},{0,0,1} };
+    for (const auto& kv : cells_) {
+        const openvdb::Coord& c = kv.first;
+        int v0 = kv.second.vertex_index;
+        // XY face
+        auto it1 = cells_.find(c + neighbors[0]);
+        auto it2 = cells_.find(c + neighbors[1]);
+        auto it3 = cells_.find(c + neighbors[0] + neighbors[1]);
+        if (it1!=cells_.end() && it2!=cells_.end() && it3!=cells_.end()) {
+            triangles_.push_back({v0, it1->second.vertex_index, it3->second.vertex_index});
+            triangles_.push_back({v0, it3->second.vertex_index, it2->second.vertex_index});
+        }
+        // XZ face
+        it1 = cells_.find(c + neighbors[0]);
+        it2 = cells_.find(c + neighbors[2]);
+        it3 = cells_.find(c + neighbors[0] + neighbors[2]);
+        if (it1!=cells_.end() && it2!=cells_.end() && it3!=cells_.end()) {
+            triangles_.push_back({v0, it1->second.vertex_index, it3->second.vertex_index});
+            triangles_.push_back({v0, it3->second.vertex_index, it2->second.vertex_index});
+        }
+        // YZ face
+        it1 = cells_.find(c + neighbors[1]);
+        it2 = cells_.find(c + neighbors[2]);
+        it3 = cells_.find(c + neighbors[1] + neighbors[2]);
+        if (it1!=cells_.end() && it2!=cells_.end() && it3!=cells_.end()) {
+            triangles_.push_back({v0, it1->second.vertex_index, it3->second.vertex_index});
+            triangles_.push_back({v0, it3->second.vertex_index, it2->second.vertex_index});
+        }
+    }
+}
+
+void DualContouringExtractor::buildPCLMesh(pcl::PolygonMesh& mesh){
+    pcl::PointCloud<pcl::PointXYZ> cloud;
+    cloud.reserve(vertices_.size());
+    for(const auto& v: vertices_) cloud.emplace_back(v.x(),v.y(),v.z());
+    pcl::toPCLPointCloud2(cloud, mesh.cloud);
+    mesh.polygons.clear();
+    mesh.polygons.reserve(triangles_.size());
+    for(const auto& t: triangles_){
+        pcl::Vertices v; v.vertices={t[0],t[1],t[2]};
+        mesh.polygons.push_back(v);
+    }
+}
+
+} // namespace recon
+

--- a/recon/src/fusion/mesh_fusion.cpp
+++ b/recon/src/fusion/mesh_fusion.cpp
@@ -1,0 +1,229 @@
+#include "mesh_fusion.h"
+
+#include <igl/copyleft/cgal/mesh_boolean.h>
+#include <igl/copyleft/cgal/approximate_offset.h>
+#include <igl/copyleft/cgal/alpha_wrap.h>
+#include <igl/per_vertex_normals.h>
+#include <igl/remove_duplicate_vertices.h>
+#include <igl/remove_unreferenced.h>
+
+#include <pcl/kdtree/kdtree_flann.h>
+#include <pcl/common/impl/io.hpp>
+#include <iostream>
+#include <unordered_map>
+
+MeshFuser::MeshFuser(const MeshFusionConfig& cfg) : cfg_(cfg) {}
+
+bool MeshFuser::pclMeshToEigen(const pcl::PolygonMesh& mesh,
+                               Eigen::MatrixXd& V,
+                               Eigen::MatrixXi& F) const {
+    PointCloudT cloud;
+    pcl::fromPCLPointCloud2(mesh.cloud, cloud);
+    V.resize(cloud.size(), 3);
+    for (size_t i = 0; i < cloud.size(); ++i) {
+        const auto& p = cloud.points[i];
+        V(i, 0) = p.x;
+        V(i, 1) = p.y;
+        V(i, 2) = p.z;
+    }
+    F.resize(mesh.polygons.size(), 3);
+    for (size_t i = 0; i < mesh.polygons.size(); ++i) {
+        const auto& poly = mesh.polygons[i];
+        if (poly.vertices.size() != 3) return false;
+        F(i, 0) = poly.vertices[0];
+        F(i, 1) = poly.vertices[1];
+        F(i, 2) = poly.vertices[2];
+    }
+    return true;
+}
+
+void MeshFuser::eigenToPclMesh(const Eigen::MatrixXd& V,
+                               const Eigen::MatrixXi& F,
+                               const Eigen::MatrixXd& N,
+                               const std::vector<Eigen::Vector3f>& colors,
+                               pcl::PolygonMesh& mesh) const {
+    pcl::PointCloud<pcl::PointXYZRGBNormal> cloud;
+    cloud.resize(V.rows());
+    for (int i = 0; i < V.rows(); ++i) {
+        auto& pt = cloud.points[i];
+        pt.x = static_cast<float>(V(i,0));
+        pt.y = static_cast<float>(V(i,1));
+        pt.z = static_cast<float>(V(i,2));
+        if (N.rows() == V.rows()) {
+            pt.normal_x = static_cast<float>(N(i,0));
+            pt.normal_y = static_cast<float>(N(i,1));
+            pt.normal_z = static_cast<float>(N(i,2));
+        } else {
+            pt.normal_x = pt.normal_y = pt.normal_z = 0.f;
+        }
+        if (i < static_cast<int>(colors.size())) {
+            Eigen::Vector3f c = colors[i].cwiseMax(0.f).cwiseMin(1.f);
+            pt.r = static_cast<uint8_t>(c[0] * 255.f);
+            pt.g = static_cast<uint8_t>(c[1] * 255.f);
+            pt.b = static_cast<uint8_t>(c[2] * 255.f);
+        } else {
+            pt.r = pt.g = pt.b = 200;
+        }
+    }
+    pcl::toPCLPointCloud2(cloud, mesh.cloud);
+    mesh.polygons.resize(F.rows());
+    for (int i = 0; i < F.rows(); ++i) {
+        pcl::Vertices v;
+        v.vertices = {static_cast<uint32_t>(F(i,0)), static_cast<uint32_t>(F(i,1)), static_cast<uint32_t>(F(i,2))};
+        mesh.polygons[i] = v;
+    }
+}
+
+void MeshFuser::assignColors(const Eigen::MatrixXd& V,
+                             const pcl::PolygonMesh& shell,
+                             const pcl::PolygonMesh& detail,
+                             const typename PointNormalCloudT::ConstPtr& samples,
+                             std::vector<Eigen::Vector3f>& colors) const {
+    // 构建KD树
+    PointCloudT sample_pts;
+    pcl::copyPointCloud(*samples, sample_pts);
+    pcl::KdTreeFLANN<PointT> sample_tree;
+    sample_tree.setInputCloud(sample_pts.makeShared());
+
+    PointCloudT shell_pts;
+    pcl::fromPCLPointCloud2(shell.cloud, shell_pts);
+    pcl::KdTreeFLANN<PointT> shell_tree;
+    if (!shell_pts.empty()) shell_tree.setInputCloud(shell_pts.makeShared());
+
+    PointCloudT detail_pts;
+    pcl::fromPCLPointCloud2(detail.cloud, detail_pts);
+    pcl::KdTreeFLANN<PointT> detail_tree;
+    if (!detail_pts.empty()) detail_tree.setInputCloud(detail_pts.makeShared());
+
+    colors.resize(V.rows(), Eigen::Vector3f(0.5f,0.5f,0.5f));
+    for (int i = 0; i < V.rows(); ++i) {
+        PointT query;
+        query.x = static_cast<float>(V(i,0));
+        query.y = static_cast<float>(V(i,1));
+        query.z = static_cast<float>(V(i,2));
+
+        double ds = std::numeric_limits<double>::max();
+        double dd = std::numeric_limits<double>::max();
+        if (!shell_pts.empty()) {
+            std::vector<int> idx(1); std::vector<float> sqd(1);
+            shell_tree.nearestKSearch(query, 1, idx, sqd);
+            ds = std::sqrt(sqd[0]);
+        }
+        if (!detail_pts.empty()) {
+            std::vector<int> idx(1); std::vector<float> sqd(1);
+            detail_tree.nearestKSearch(query, 1, idx, sqd);
+            dd = std::sqrt(sqd[0]);
+        }
+
+        // shell color: average of 8 neighbours
+        Eigen::Vector3f shell_color = Eigen::Vector3f::Zero();
+        std::vector<int> sidx(8); std::vector<float> sdist(8);
+        if (sample_tree.nearestKSearch(query, 8, sidx, sdist) > 0) {
+            for (int id : sidx) {
+                const auto& pt = sample_pts.points[id];
+                shell_color += Eigen::Vector3f(pt.r, pt.g, pt.b);
+            }
+            shell_color /= (255.f * static_cast<float>(sidx.size()));
+        }
+        // detail color: nearest neighbour
+        Eigen::Vector3f detail_color = shell_color;
+        std::vector<int> didx(1); std::vector<float> ddist(1);
+        if (sample_tree.nearestKSearch(query, 1, didx, ddist) > 0) {
+            const auto& pt = sample_pts.points[didx[0]];
+            detail_color = Eigen::Vector3f(pt.r, pt.g, pt.b) / 255.f;
+        }
+
+        Eigen::Vector3f final_color;
+        if (dd < ds && dd < cfg_.detail_threshold) {
+            final_color = detail_color;
+        } else if (ds < dd && ds < cfg_.detail_threshold) {
+            final_color = shell_color;
+        } else if (ds < cfg_.blend_distance && dd < cfg_.blend_distance) {
+            final_color = cfg_.shell_color_weight * shell_color +
+                          cfg_.detail_color_weight * detail_color;
+        } else {
+            final_color = shell_color;
+        }
+        colors[i] = final_color;
+    }
+}
+
+bool MeshFuser::fuse(const pcl::PolygonMesh& shell,
+                     const pcl::PolygonMesh& detail,
+                     const typename PointNormalCloudT::ConstPtr& samples,
+                     pcl::PolygonMesh& out) {
+    Eigen::MatrixXd Vs, Vd;
+    Eigen::MatrixXi Fs, Fd;
+    if(!pclMeshToEigen(shell, Vs, Fs) || !pclMeshToEigen(detail, Vd, Fd)) {
+        std::cerr << "网格转换失败" << std::endl;
+        return false;
+    }
+
+    // 壳主导δ保护: detail - dilate(shell, δ)
+    Eigen::MatrixXd Vd_proc = Vd;
+    Eigen::MatrixXi Fd_proc = Fd;
+    if (cfg_.shell_priority && cfg_.shell_dilation > 0.0 && Vs.rows() > 0 && Vd.rows() > 0) {
+        try {
+            Eigen::MatrixXd Vdil; Eigen::MatrixXi Fdil;
+            igl::copyleft::cgal::approximate_offset(Vs, Fs, cfg_.shell_dilation, Vdil, Fdil);
+            igl::copyleft::cgal::mesh_boolean(Vd, Fd, Vdil, Fdil,
+                igl::MESH_BOOLEAN_TYPE_MINUS, Vd_proc, Fd_proc);
+        } catch (const std::exception& e) {
+            std::cerr << "δ保护失败: " << e.what() << std::endl;
+            Vd_proc = Vd; Fd_proc = Fd;
+        }
+    }
+
+    Eigen::MatrixXd V; Eigen::MatrixXi F;
+    bool boolean_ok = true;
+    try {
+        igl::copyleft::cgal::mesh_boolean(Vs, Fs, Vd_proc, Fd_proc,
+            igl::MESH_BOOLEAN_TYPE_UNION, V, F);
+    } catch (const std::exception& e) {
+        std::cerr << "布尔运算失败: " << e.what() << std::endl;
+        boolean_ok = false;
+    }
+
+    // Alpha包装回退
+    if (!boolean_ok) {
+        if (cfg_.enable_alpha_fallback) {
+            try {
+                Eigen::MatrixXd Vstack(Vs.rows() + Vd_proc.rows(), 3);
+                Vstack << Vs, Vd_proc;
+                Eigen::MatrixXi Fstack(Fs.rows() + Fd_proc.rows(), 3);
+                Fstack << Fs, (Fd_proc.array() + Vs.rows()).matrix();
+                igl::copyleft::cgal::alpha_wrap_3D(
+                    Vstack, Fstack,
+                    cfg_.alpha_offset,
+                    cfg_.alpha_offset * 0.5,
+                    V, F);
+                boolean_ok = true;
+            } catch (const std::exception& e) {
+                std::cerr << "Alpha包装回退失败: " << e.what() << std::endl;
+                return false;
+            }
+        } else {
+            return false;
+        }
+    }
+
+    // Vertex welding
+    Eigen::MatrixXd Vw, Vc; Eigen::MatrixXi Fw, Fc;
+    Eigen::VectorXi I, J;
+    igl::remove_duplicate_vertices(V, F, cfg_.weld_threshold, Vw, I, Fw, J);
+    igl::remove_unreferenced(Vw, Fw, Vc, Fc, I, J);
+    V = Vc; F = Fc;
+
+    // Recompute normals
+    Eigen::MatrixXd N;
+    if (cfg_.recompute_normals) {
+        igl::per_vertex_normals(V, F, N);
+    }
+
+    std::vector<Eigen::Vector3f> colors;
+    assignColors(V, shell, detail, samples, colors);
+
+    eigenToPclMesh(V, F, N, colors, out);
+    return true;
+}
+

--- a/recon/src/fusion/mesh_fusion.h
+++ b/recon/src/fusion/mesh_fusion.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <pcl/point_types.h>
+#include <pcl/point_cloud.h>
+#include <pcl/PolygonMesh.h>
+#include <Eigen/Dense>
+#include <vector>
+
+struct MeshFusionConfig {
+    bool shell_priority = true;               // 外壳优先策略
+    double detail_threshold = 0.005;          // 细节距离阈值(米)
+    double shell_dilation = 0.005;            // 壳主导保护的膨胀δ(米)
+    bool use_cgal = true;                    // 是否使用CGAL后端
+    double boolean_tolerance = 0.001;        // 布尔运算容差
+    double weld_threshold = 0.002;           // 顶点焊接阈值
+    bool recompute_normals = true;           // 是否重估法向量
+    bool consistent_orientation = true;      // 法向量一致方向
+    double shell_color_weight = 0.7;         // 颜色混合权重-外壳
+    double detail_color_weight = 0.3;        // 颜色混合权重-细节
+    double blend_distance = 0.01;            // 颜色过渡距离
+    bool enable_alpha_fallback = true;       // 布尔失败时使用Alpha包装
+    double alpha_offset = 0.002;             // Alpha包装偏移
+};
+
+class MeshFuser {
+public:
+    explicit MeshFuser(const MeshFusionConfig& cfg);
+
+    using PointT = pcl::PointXYZRGB;
+    using PointCloudT = pcl::PointCloud<PointT>;
+    using PointNormalT = pcl::PointXYZRGBNormal;
+    using PointNormalCloudT = pcl::PointCloud<PointNormalT>;
+
+    /**
+     * Fuse shell and detail meshes into a single mesh.
+     * @param shell   外壳网格
+     * @param detail  细节网格
+     * @param samples 原始带颜色点云
+     * @param out     输出融合后网格
+     */
+    bool fuse(const pcl::PolygonMesh& shell,
+              const pcl::PolygonMesh& detail,
+              const typename PointNormalCloudT::ConstPtr& samples,
+              pcl::PolygonMesh& out);
+
+private:
+    MeshFusionConfig cfg_;
+
+    bool pclMeshToEigen(const pcl::PolygonMesh& mesh,
+                        Eigen::MatrixXd& V,
+                        Eigen::MatrixXi& F) const;
+
+    void eigenToPclMesh(const Eigen::MatrixXd& V,
+                        const Eigen::MatrixXi& F,
+                        const Eigen::MatrixXd& N,
+                        const std::vector<Eigen::Vector3f>& colors,
+                        pcl::PolygonMesh& mesh) const;
+
+    void assignColors(const Eigen::MatrixXd& V,
+                      const pcl::PolygonMesh& shell,
+                      const pcl::PolygonMesh& detail,
+                      const typename PointNormalCloudT::ConstPtr& samples,
+                      std::vector<Eigen::Vector3f>& colors) const;
+};
+

--- a/recon/src/graph_cut/graph_cut.cpp
+++ b/recon/src/graph_cut/graph_cut.cpp
@@ -1,0 +1,361 @@
+#include "graph_cut.h"
+#include <pcl/common/common.h>
+#include <pcl/kdtree/kdtree_flann.h>
+#include <queue>
+#include <chrono>
+#include <limits>
+#include <algorithm>
+#include <Eigen/Eigenvalues>
+
+namespace recon {
+
+GraphCutOptimizer::GraphCutOptimizer(const GraphCutConfig& config)
+    : config_(config) {}
+
+GraphCutOptimizer::~GraphCutOptimizer() = default;
+
+bool GraphCutOptimizer::optimize(const UDFGridT::Ptr& udf_grid,
+                                 const ConfidenceGridT::Ptr& confidence_grid,
+                                 const PointCloudT::Ptr& cloud,
+                                 LabelGridT::Ptr& label_grid) {
+    if (!udf_grid || !confidence_grid || !cloud) return false;
+    auto start = std::chrono::high_resolution_clock::now();
+    nodes_.clear();
+    edges_.clear();
+    coord_to_node_.clear();
+    transform_ = udf_grid->transform().copy();
+    cloud_ = cloud;
+    kdtree_.setInputCloud(cloud);
+    if (!buildGraph(udf_grid, confidence_grid, cloud)) return false;
+    stats_.total_nodes = static_cast<int>(nodes_.size());
+    stats_.total_edges = static_cast<int>(edges_.size());
+    if (!solveMaxFlow()) return false;
+    buildLabelGrid(label_grid);
+    for (const auto& n : nodes_) {
+        if (n.label == Label::INSIDE) stats_.inside_nodes++; else stats_.free_nodes++;
+    }
+    auto end = std::chrono::high_resolution_clock::now();
+    stats_.optimization_time = std::chrono::duration<double>(end - start).count();
+    return true;
+}
+
+bool GraphCutOptimizer::buildGraph(const UDFGridT::Ptr& udf_grid,
+                                   const ConfidenceGridT::Ptr& confidence_grid,
+                                   const PointCloudT::Ptr& cloud) {
+    auto udf_accessor = udf_grid->getConstAccessor();
+    auto conf_accessor = confidence_grid->getConstAccessor();
+    for (auto iter = udf_grid->cbeginValueOn(); iter; ++iter) {
+        openvdb::Coord coord = iter.getCoord();
+        float udf = iter.getValue();
+        float conf = conf_accessor.getValue(coord);
+        addVoxelNode(coord, udf, conf, cloud);
+    }
+    if (nodes_.empty()) return false;
+    // 统计最大密度
+    max_density_ = 1.0f;
+    for (const auto& n : nodes_) max_density_ = std::max(max_density_, n.local_density);
+    // 自由空间种子与泛洪
+    free_seeds_ = generateFreeSpaceSeeds(cloud);
+    floodFillFreeRegion(free_seeds_);
+    // 可见性成本
+    for (auto& n : nodes_) {
+        n.visibility_cost = computeVisibilityCost(n.coord, free_seeds_, cloud);
+    }
+    buildEdges();
+    return true;
+}
+
+void GraphCutOptimizer::addVoxelNode(const openvdb::Coord& coord,
+                                     float udf_value,
+                                     float confidence,
+                                     const PointCloudT::Ptr& cloud) {
+    VoxelNode node;
+    node.coord = coord;
+    node.udf_value = udf_value;
+    node.confidence = confidence;
+    node.is_planar = isPlanarRegion(coord, cloud);
+    node.local_density = computeLocalDensity(coord, cloud);
+    int index = static_cast<int>(nodes_.size());
+    nodes_.push_back(node);
+    coord_to_node_[coord] = index;
+}
+
+void GraphCutOptimizer::buildEdges() {
+    for (size_t i = 0; i < nodes_.size(); ++i) {
+        const auto& node = nodes_[i];
+        for (const auto& ncoord : getNeighbors(node.coord)) {
+            auto it = coord_to_node_.find(ncoord);
+            if (it == coord_to_node_.end()) continue;
+            int j = it->second;
+            if (j <= static_cast<int>(i)) continue; // avoid duplicates
+            float w = computeSmoothWeight(node, nodes_[j]);
+            edges_.push_back({static_cast<int>(i), j, w, node.is_planar && nodes_[j].is_planar});
+        }
+    }
+}
+
+std::pair<float, float> GraphCutOptimizer::computeDataCosts(const VoxelNode& node,
+                                                           const PointCloudT::Ptr& /*cloud*/) {
+    float phi = std::min(node.udf_value / 0.03f, 1.0f);
+    float inside = node.confidence * phi * config_.inside_cost_multiplier;
+    float alpha = node.is_planar ? config_.planar_alpha : config_.detail_alpha;
+    float free = config_.free_cost_base + (node.is_free_region ? -alpha : alpha);
+    free = std::max(0.0f, free);
+    free += config_.visibility_weight * node.visibility_cost;
+    return {free, inside};
+}
+
+float GraphCutOptimizer::computeSmoothWeight(const VoxelNode& node1, const VoxelNode& node2) {
+    float lambda = (node1.is_planar && node2.is_planar) ?
+                   config_.planar_lambda : config_.detail_lambda;
+    float w = config_.base_weight * lambda;
+    if (node1.is_planar && node2.is_planar) w *= config_.planar_multiplier;
+    if (node1.is_planar != node2.is_planar) w *= config_.cross_plane_multiplier;
+    if (config_.density_adaptive && max_density_ > 1e-6f) {
+        float avg = 0.5f * (node1.local_density + node2.local_density);
+        w *= avg / max_density_;
+    }
+    return w;
+}
+
+bool GraphCutOptimizer::isPlanarRegion(const openvdb::Coord& coord, const PointCloudT::Ptr& /*cloud*/) {
+    PointT search;
+    auto world = transform_->indexToWorld(coord);
+    search.x = world.x(); search.y = world.y(); search.z = world.z();
+    std::vector<int> idx(20);
+    std::vector<float> dist2(20);
+    if (kdtree_.nearestKSearch(search, 20, idx, dist2) < 6) return false;
+    Eigen::Vector3f centroid = Eigen::Vector3f::Zero();
+    for (int i = 0; i < (int)idx.size(); ++i) {
+        const auto& p = cloud_->points[idx[i]];
+        centroid += Eigen::Vector3f(p.x, p.y, p.z);
+    }
+    centroid /= static_cast<float>(idx.size());
+    Eigen::Matrix3f cov = Eigen::Matrix3f::Zero();
+    for (int i = 0; i < (int)idx.size(); ++i) {
+        const auto& p = cloud_->points[idx[i]];
+        Eigen::Vector3f v(p.x, p.y, p.z);
+        v -= centroid;
+        cov += v * v.transpose();
+    }
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix3f> solver(cov);
+    auto evals = solver.eigenvalues();
+    float curvature = evals[0] / evals.sum();
+    return curvature < 0.01f;
+}
+
+float GraphCutOptimizer::computeLocalDensity(const openvdb::Coord& coord, const PointCloudT::Ptr& /*cloud*/) {
+    PointT search;
+    auto world = transform_->indexToWorld(coord);
+    search.x = world.x(); search.y = world.y(); search.z = world.z();
+    std::vector<int> idx(16);
+    std::vector<float> dist2(16);
+    int count = kdtree_.nearestKSearch(search, 16, idx, dist2);
+    return static_cast<float>(count);
+}
+
+std::vector<openvdb::Coord> GraphCutOptimizer::generateFreeSpaceSeeds(const PointCloudT::Ptr& cloud) {
+    std::vector<openvdb::Coord> seeds;
+    pcl::PointXYZRGBNormal min_pt, max_pt;
+    pcl::getMinMax3D(*cloud, min_pt, max_pt);
+    for (float x = min_pt.x; x <= max_pt.x; x += config_.seed_spacing) {
+        for (float y = min_pt.y; y <= max_pt.y; y += config_.seed_spacing) {
+            for (float z = min_pt.z; z <= max_pt.z; z += config_.seed_spacing) {
+                PointT p; p.x = x; p.y = y; p.z = z;
+                std::vector<int> idx(1); std::vector<float> dist2(1);
+                if (kdtree_.nearestKSearch(p, 1, idx, dist2) == 0) continue;
+                if (std::sqrt(dist2[0]) >= config_.min_distance_to_surface) {
+                    openvdb::Vec3d pos(x, y, z);
+                    seeds.push_back(transform_->worldToIndexCellCentered(pos));
+                }
+            }
+        }
+    }
+    return seeds;
+}
+
+float GraphCutOptimizer::computeVisibilityCost(const openvdb::Coord& coord,
+                                               const std::vector<openvdb::Coord>& seeds,
+                                               const PointCloudT::Ptr& /*cloud*/) {
+    if (seeds.empty()) return 0.0f;
+    auto target = transform_->indexToWorld(coord);
+    int visible = 0;
+    for (const auto& s : seeds) {
+        auto start = transform_->indexToWorld(s);
+        Eigen::Vector3f dir(target.x() - start.x(), target.y() - start.y(), target.z() - start.z());
+        float len = dir.norm();
+        int steps = std::max(1, static_cast<int>(len / config_.min_distance_to_surface));
+        Eigen::Vector3f step = dir / static_cast<float>(steps);
+        Eigen::Vector3f pos(start.x(), start.y(), start.z());
+        bool blocked = false;
+        for (int i = 0; i < steps; ++i) {
+            pos += step;
+            PointT q; q.x = pos.x(); q.y = pos.y(); q.z = pos.z();
+            std::vector<int> idx(1); std::vector<float> dist2(1);
+            if (kdtree_.nearestKSearch(q, 1, idx, dist2) > 0 &&
+                dist2[0] < config_.min_distance_to_surface * config_.min_distance_to_surface) {
+                blocked = true; break;
+            }
+        }
+        if (!blocked) visible++;
+    }
+    return 1.0f - static_cast<float>(visible) / static_cast<float>(seeds.size());
+}
+
+bool GraphCutOptimizer::solveMaxFlow() {
+    int n = static_cast<int>(nodes_.size());
+    int source = n;
+    int sink = n + 1;
+    SimpleMaxFlowSolver solver(n + 2);
+    for (int i = 0; i < n; ++i) {
+        auto costs = computeDataCosts(nodes_[i], cloud_);
+        solver.addEdge(source, i, costs.first);
+        solver.addEdge(i, sink, costs.second);
+    }
+    for (const auto& e : edges_) {
+        solver.addEdge(e.node1, e.node2, e.weight);
+        solver.addEdge(e.node2, e.node1, e.weight);
+    }
+    stats_.max_flow_value = solver.maxFlow(source, sink);
+    for (int i = 0; i < n; ++i) {
+        nodes_[i].label = solver.isSourceSide(i) ? Label::FREE : Label::INSIDE;
+    }
+    return true;
+}
+
+void GraphCutOptimizer::buildLabelGrid(LabelGridT::Ptr& label_grid) {
+    label_grid = LabelGridT::create(0);
+    label_grid->setTransform(transform_);
+    auto accessor = label_grid->getAccessor();
+    for (const auto& node : nodes_) {
+        accessor.setValue(node.coord, static_cast<int>(node.label));
+    }
+}
+
+std::vector<openvdb::Coord> GraphCutOptimizer::getNeighbors(const openvdb::Coord& coord) {
+    static const int offsets[6][3] = {
+        {1,0,0},{-1,0,0},{0,1,0},{0,-1,0},{0,0,1},{0,0,-1}
+    };
+    std::vector<openvdb::Coord> res;
+    res.reserve(6);
+    for (const auto& o : offsets) {
+        res.emplace_back(coord.x() + o[0], coord.y() + o[1], coord.z() + o[2]);
+    }
+    return res;
+}
+
+bool GraphCutOptimizer::isValidCoord(const openvdb::Coord& /*coord*/) {
+    return true;
+}
+
+float GraphCutOptimizer::computeDistance(const openvdb::Coord& c1, const openvdb::Coord& c2) {
+    auto w1 = transform_->indexToWorld(c1);
+    auto w2 = transform_->indexToWorld(c2);
+    return static_cast<float>((w1 - w2).length());
+}
+
+void GraphCutOptimizer::floodFillFreeRegion(const std::vector<openvdb::Coord>& seeds) {
+    std::queue<int> q;
+    std::vector<bool> visited(nodes_.size(), false);
+    for (const auto& s : seeds) {
+        auto it = coord_to_node_.find(s);
+        if (it == coord_to_node_.end()) continue;
+        int idx = it->second;
+        if (nodes_[idx].udf_value < config_.min_distance_to_surface) continue;
+        nodes_[idx].is_free_region = true;
+        visited[idx] = true;
+        q.push(idx);
+    }
+    while (!q.empty()) {
+        int i = q.front(); q.pop();
+        const auto& node = nodes_[i];
+        for (const auto& ncoord : getNeighbors(node.coord)) {
+            auto it = coord_to_node_.find(ncoord);
+            if (it == coord_to_node_.end()) continue;
+            int j = it->second;
+            if (visited[j]) continue;
+            if (nodes_[j].udf_value < config_.min_distance_to_surface) continue;
+            visited[j] = true;
+            nodes_[j].is_free_region = true;
+            q.push(j);
+        }
+    }
+}
+
+// SimpleMaxFlowSolver implementation
+
+SimpleMaxFlowSolver::SimpleMaxFlowSolver(int n) : graph_(n), level_(n), iter_(n), n_(n), source_side_(n,false) {}
+
+void SimpleMaxFlowSolver::addEdge(int from, int to, float cap) {
+    graph_[from].push_back(Edge{to, static_cast<int>(graph_[to].size()), cap});
+    graph_[to].push_back(Edge{from, static_cast<int>(graph_[from].size()) - 1, 0.0f});
+}
+
+bool SimpleMaxFlowSolver::bfs(int s, int t) {
+    std::fill(level_.begin(), level_.end(), -1);
+    std::queue<int> q;
+    level_[s] = 0;
+    q.push(s);
+    while(!q.empty()) {
+        int v = q.front(); q.pop();
+        for(const auto& e : graph_[v]) {
+            if(e.cap > 1e-6 && level_[e.to] < 0) {
+                level_[e.to] = level_[v] + 1;
+                q.push(e.to);
+            }
+        }
+    }
+    return level_[t] >= 0;
+}
+
+float SimpleMaxFlowSolver::dfs(int v, int t, float f) {
+    if(v == t) return f;
+    for(int &i = iter_[v]; i < static_cast<int>(graph_[v].size()); ++i) {
+        Edge &e = graph_[v][i];
+        if(e.cap > 1e-6 && level_[v] < level_[e.to]) {
+            float d = dfs(e.to, t, std::min(f, e.cap));
+            if(d > 1e-6) {
+                e.cap -= d;
+                graph_[e.to][e.rev].cap += d;
+                return d;
+            }
+        }
+    }
+    return 0.0f;
+}
+
+float SimpleMaxFlowSolver::maxFlow(int s, int t) {
+    float flow = 0.0f;
+    const float INF = std::numeric_limits<float>::max();
+    while(bfs(s,t)) {
+        std::fill(iter_.begin(), iter_.end(), 0);
+        float f;
+        while((f = dfs(s,t,INF)) > 1e-6) {
+            flow += f;
+        }
+    }
+    // mark source side
+    std::vector<bool> visited(n_, false);
+    std::queue<int> q;
+    q.push(s);
+    visited[s] = true;
+    while(!q.empty()) {
+        int v = q.front(); q.pop();
+        source_side_[v] = true;
+        for(const auto& e : graph_[v]) {
+            if(e.cap > 1e-6 && !visited[e.to]) {
+                visited[e.to] = true;
+                q.push(e.to);
+            }
+        }
+    }
+    return flow;
+}
+
+bool SimpleMaxFlowSolver::isSourceSide(int v) const {
+    if (v < 0 || v >= n_) return false;
+    return source_side_[v];
+}
+
+} // namespace recon
+

--- a/recon/src/graph_cut/graph_cut.h
+++ b/recon/src/graph_cut/graph_cut.h
@@ -64,6 +64,8 @@ struct VoxelNode {
     float confidence;               // 置信度
     bool is_planar;                 // 是否为平面区域
     float local_density;            // 局部密度
+    bool is_free_region = false;    // 是否可达自由空间
+    float visibility_cost = 0.0f;   // 可见性惩罚
     Label label = Label::FREE;      // 分配的标签
 };
 
@@ -140,7 +142,12 @@ private:
     
     std::vector<VoxelNode> nodes_;
     std::vector<GraphEdge> edges_;
-    std::unordered_map<openvdb::Coord, int> coord_to_node_;
+    std::unordered_map<openvdb::Coord, int, openvdb::Coord::Hash> coord_to_node_;
+    openvdb::math::Transform::Ptr transform_;
+    PointCloudT::Ptr cloud_;
+    pcl::KdTreeFLANN<PointT> kdtree_;
+    std::vector<openvdb::Coord> free_seeds_;
+    float max_density_ = 1.0f;
     
     /**
      * 构建图结构
@@ -219,6 +226,11 @@ private:
      * 计算两个坐标之间的距离
      */
     float computeDistance(const openvdb::Coord& coord1, const openvdb::Coord& coord2);
+
+    /**
+     * 自由空间泛洪
+     */
+    void floodFillFreeRegion(const std::vector<openvdb::Coord>& seeds);
 };
 
 /**

--- a/recon/src/pipeline.cpp
+++ b/recon/src/pipeline.cpp
@@ -16,23 +16,37 @@
 #include <pcl/io/obj_io.h>
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
+#include <pcl/conversions.h>
+#include <pcl/PolygonMesh.h>
 #include <pcl/filters/statistical_outlier_removal.h>
 #include <pcl/filters/radius_outlier_removal.h>
+#include <pcl/filters/crop_box.h>
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/filters/bilateral.h>
 #include <pcl/features/normal_3d_omp.h>
 #include <pcl/kdtree/kdtree_flann.h>
+#include <pcl/surface/mls.h>
 #include <pcl/surface/gp3.h>
 #include <pcl/surface/marching_cubes_hoppe.h>
 
 // OpenVDB库
 #include <openvdb/openvdb.h>
-#include <openvdb/tools/ParticlesToLevelSet.h>
-#include <openvdb/tools/VolumeToMesh.h>
-#include <openvdb/tools/LevelSetFilter.h>
+
+#include "udf_builder/udf_builder.h"
+#include "graph_cut/graph_cut.h"
+#include "dual_contouring/dual_contouring.h"
+#include "detail_reconstruction.h"
+#include "detail_reconstruction.cpp"
+#include "fusion/mesh_fusion.h"
+#include "fusion/mesh_fusion.cpp"
 
 // 标准库
 #include <vector>
 #include <algorithm>
 #include <cmath>
+#include <queue>
+#include <limits>
+#include <Eigen/Dense>
 
 // 类型定义
 using PointT = pcl::PointXYZRGB;
@@ -47,55 +61,115 @@ using PointNormalCloudT = pcl::PointCloud<PointNormalT>;
 class DataPreprocessor {
 public:
     struct Config {
-        double unit_scale = 1.0;
-        int knn_neighbors = 16;
-        double stddev_thresh = 2.0;
-        double radius_multiplier = 2.0;
-        int min_neighbors = 8;
-        int normal_k = 32;
+        double unit_scale = 1.0;              // 单位转换比例
+        bool enable_crop = false;            // 是否启用裁剪
+        Eigen::Vector4f crop_min = Eigen::Vector4f(-std::numeric_limits<float>::max(),
+                                                  -std::numeric_limits<float>::max(),
+                                                  -std::numeric_limits<float>::max(), 1.0f);
+        Eigen::Vector4f crop_max = Eigen::Vector4f(std::numeric_limits<float>::max(),
+                                                  std::numeric_limits<float>::max(),
+                                                  std::numeric_limits<float>::max(), 1.0f);
+        int knn_neighbors = 16;              // kNN邻居数
+        double stddev_thresh = 2.0;          // 统计异常值阈值
+        double radius_multiplier = 2.0;      // 半径异常值倍数
+        int min_neighbors = 8;               // 半径内最小邻居数
+        bool use_mls = false;                // 是否使用MLS平滑
+        double mls_radius = 0.0;             // MLS搜索半径
+        bool use_bilateral = false;          // 是否使用双边滤波
+        double bilateral_sigma_s = 0.03;     // 双边滤波空间sigma
+        double bilateral_sigma_r = 0.05;     // 双边滤波强度sigma
+        bool use_voxel_downsample = false;   // 是否进行体素下采样
+        float voxel_size = 0.0f;             // 下采样体素大小
+        int normal_k = 32;                   // 法向估计的邻居数
     };
 
-    DataPreprocessor(const Config& config) : config_(config) {}
+    struct Statistics {
+        double median_knn_distance = 0.0;    // kNN距离中位数
+        double p95_knn_distance = 0.0;       // kNN距离95百分位
+        size_t input_point_count = 0;        // 输入点数量
+        size_t output_point_count = 0;       // 输出点数量
+    };
+
+    explicit DataPreprocessor(const Config& config) : config_(config) {}
+
+    const Statistics& stats() const { return stats_; }
 
     /**
      * 执行完整的预处理管道
      */
     bool process(PointCloudT::Ptr input, PointNormalCloudT::Ptr output) {
+        stats_ = Statistics{};
+        stats_.input_point_count = input->size();
         std::cout << "开始数据预处理..." << std::endl;
-        
+
         // 1. 坐标统一和单位标准化
         if (!normalizeCoordinates(input)) {
             std::cerr << "坐标标准化失败" << std::endl;
             return false;
         }
-        
-        // 2. 统计异常值去除
+
+        // 2. 可选裁剪
+        if (config_.enable_crop) {
+            if (!cropPointCloud(input)) {
+                std::cerr << "裁剪失败" << std::endl;
+                return false;
+            }
+        }
+
+        // 3. 计算密度统计
+        if (!computeDensityStats(input, stats_.median_knn_distance, stats_.p95_knn_distance)) {
+            std::cerr << "密度统计计算失败" << std::endl;
+            return false;
+        }
+        std::cout << "密度统计：median=" << stats_.median_knn_distance
+                  << "  p95=" << stats_.p95_knn_distance << std::endl;
+
+        // 4. 统计异常值去除
         PointCloudT::Ptr filtered(new PointCloudT);
         if (!removeStatisticalOutliers(input, filtered)) {
             std::cerr << "统计异常值去除失败" << std::endl;
             return false;
         }
-        
-        // 3. 半径异常值去除
+
+        // 5. 半径异常值去除
         PointCloudT::Ptr radius_filtered(new PointCloudT);
-        if (!removeRadiusOutliers(filtered, radius_filtered)) {
+        if (!removeRadiusOutliers(filtered, radius_filtered, stats_.median_knn_distance)) {
             std::cerr << "半径异常值去除失败" << std::endl;
             return false;
         }
-        
-        // 4. 法向量估计
-        if (!estimateNormals(radius_filtered, output)) {
+
+        // 6. 特征保持去噪
+        PointCloudT::Ptr denoised(new PointCloudT);
+        if (!applyDenoising(radius_filtered, denoised, stats_.median_knn_distance)) {
+            std::cerr << "去噪失败" << std::endl;
+            return false;
+        }
+
+        // 7. 密度平衡采样
+        PointCloudT::Ptr sampled(new PointCloudT);
+        if (!applySampling(denoised, sampled)) {
+            std::cerr << "采样失败" << std::endl;
+            return false;
+        }
+
+        // 8. 法向量估计
+        if (!estimateNormals(sampled, output)) {
             std::cerr << "法向量估计失败" << std::endl;
             return false;
         }
-        
-        std::cout << "预处理完成，输入点数: " << input->size() 
-                  << ", 输出点数: " << output->size() << std::endl;
+
+        // 9. 法向量全局定向
+        orientNormals(output);
+
+        stats_.output_point_count = output->size();
+        std::cout << "预处理完成，输入点数: " << stats_.input_point_count
+                  << ", 输出点数: " << stats_.output_point_count << std::endl;
         return true;
     }
 
 private:
     Config config_;
+    Statistics stats_;
 
     bool normalizeCoordinates(PointCloudT::Ptr cloud) {
         for (auto& point : cloud->points) {
@@ -103,6 +177,43 @@ private:
             point.y *= config_.unit_scale;
             point.z *= config_.unit_scale;
         }
+        return true;
+    }
+
+    bool cropPointCloud(PointCloudT::Ptr cloud) {
+        pcl::CropBox<PointT> crop;
+        crop.setMin(config_.crop_min);
+        crop.setMax(config_.crop_max);
+        crop.setInputCloud(cloud);
+        PointCloudT cropped;
+        crop.filter(cropped);
+        *cloud = cropped;
+        return true;
+    }
+
+    bool computeDensityStats(PointCloudT::Ptr cloud, double& median_d, double& p95_d) {
+        pcl::KdTreeFLANN<PointT> tree;
+        tree.setInputCloud(cloud);
+        std::vector<float> distances;
+        distances.reserve(cloud->size());
+
+        std::vector<int> idx(config_.knn_neighbors);
+        std::vector<float> sqd(config_.knn_neighbors);
+        for (size_t i = 0; i < cloud->size(); ++i) {
+            if (tree.nearestKSearch(cloud->points[i], config_.knn_neighbors, idx, sqd) > 0) {
+                distances.push_back(std::sqrt(sqd.back()));
+            }
+        }
+
+        if (distances.empty()) return false;
+
+        auto mid_it = distances.begin() + distances.size() / 2;
+        std::nth_element(distances.begin(), mid_it, distances.end());
+        median_d = distances[distances.size() / 2];
+
+        auto p95_it = distances.begin() + static_cast<size_t>(0.95 * distances.size());
+        std::nth_element(distances.begin(), p95_it, distances.end());
+        p95_d = distances[static_cast<size_t>(0.95 * distances.size())];
         return true;
     }
 
@@ -115,25 +226,7 @@ private:
         return true;
     }
 
-    bool removeRadiusOutliers(PointCloudT::Ptr input, PointCloudT::Ptr output) {
-        // 计算中位数距离
-        pcl::KdTreeFLANN<PointT> tree;
-        tree.setInputCloud(input);
-        std::vector<float> distances;
-        
-        for (size_t i = 0; i < input->size() && i < 1000; ++i) {
-            std::vector<int> idx(config_.knn_neighbors);
-            std::vector<float> sqd(config_.knn_neighbors);
-            if (tree.nearestKSearch(input->points[i], config_.knn_neighbors, idx, sqd) > 0) {
-                distances.push_back(std::sqrt(sqd.back()));
-            }
-        }
-        
-        if (distances.empty()) return false;
-        
-        std::nth_element(distances.begin(), distances.begin() + distances.size()/2, distances.end());
-        double median_distance = distances[distances.size()/2];
-        
+    bool removeRadiusOutliers(PointCloudT::Ptr input, PointCloudT::Ptr output, double median_distance) {
         pcl::RadiusOutlierRemoval<PointT> ror;
         ror.setInputCloud(input);
         ror.setRadiusSearch(config_.radius_multiplier * median_distance);
@@ -142,22 +235,59 @@ private:
         return true;
     }
 
+    bool applyDenoising(PointCloudT::Ptr input, PointCloudT::Ptr output, double median_distance) {
+        if (config_.use_mls) {
+            pcl::MovingLeastSquares<PointT, PointT> mls;
+            mls.setInputCloud(input);
+            pcl::search::KdTree<PointT>::Ptr tree(new pcl::search::KdTree<PointT>);
+            mls.setSearchMethod(tree);
+            double radius = config_.mls_radius > 0.0 ? config_.mls_radius : 3.0 * median_distance;
+            mls.setSearchRadius(radius);
+            mls.setPolynomialFit(true);
+            mls.setComputeNormals(false);
+            mls.process(*output);
+            return true;
+        } else if (config_.use_bilateral) {
+            pcl::BilateralFilter<PointT> bf;
+            bf.setInputCloud(input);
+            bf.setSigmaS(config_.bilateral_sigma_s);
+            bf.setSigmaR(config_.bilateral_sigma_r);
+            bf.filter(*output);
+            return true;
+        }
+
+        // 无去噪，直接复制
+        *output = *input;
+        return true;
+    }
+
+    bool applySampling(PointCloudT::Ptr input, PointCloudT::Ptr output) {
+        if (config_.use_voxel_downsample && config_.voxel_size > 0.0f) {
+            pcl::VoxelGrid<PointT> vg;
+            vg.setInputCloud(input);
+            vg.setLeafSize(config_.voxel_size, config_.voxel_size, config_.voxel_size);
+            vg.filter(*output);
+            return true;
+        }
+
+        *output = *input;
+        return true;
+    }
+
     bool estimateNormals(PointCloudT::Ptr input, PointNormalCloudT::Ptr output) {
-        // 估计法向量
         pcl::NormalEstimationOMP<PointT, pcl::Normal> ne;
         pcl::PointCloud<pcl::Normal>::Ptr normals(new pcl::PointCloud<pcl::Normal>);
         pcl::search::KdTree<PointT>::Ptr tree(new pcl::search::KdTree<PointT>());
-        
+
         ne.setInputCloud(input);
         ne.setSearchMethod(tree);
         ne.setKSearch(config_.normal_k);
         ne.setNumberOfThreads(4);
         ne.compute(*normals);
-        
-        // 合并点和法向量
+
         output->clear();
         output->reserve(input->size());
-        
+
         for (size_t i = 0; i < input->size(); ++i) {
             PointNormalT point;
             point.x = input->points[i].x;
@@ -166,151 +296,133 @@ private:
             point.r = input->points[i].r;
             point.g = input->points[i].g;
             point.b = input->points[i].b;
-            
+
             if (i < normals->size()) {
                 point.normal_x = normals->points[i].normal_x;
                 point.normal_y = normals->points[i].normal_y;
                 point.normal_z = normals->points[i].normal_z;
                 point.curvature = normals->points[i].curvature;
             }
-            
+
             output->push_back(point);
         }
-        
+
+        return true;
+    }
+
+    void orientNormals(PointNormalCloudT::Ptr cloud) {
+        if (cloud->empty()) return;
+
+        pcl::KdTreeFLANN<PointNormalT> tree;
+        tree.setInputCloud(cloud);
+        std::vector<bool> visited(cloud->size(), false);
+        std::queue<int> q;
+
+        q.push(0);
+        visited[0] = true;
+
+        std::vector<int> idx(config_.normal_k);
+        std::vector<float> sqd(config_.normal_k);
+        while (!q.empty()) {
+            int curr = q.front();
+            q.pop();
+            auto& curr_pt = cloud->points[curr];
+
+            int n = tree.nearestKSearch(curr_pt, config_.normal_k, idx, sqd);
+            for (int i = 0; i < n; ++i) {
+                int ni = idx[i];
+                if (visited[ni]) continue;
+
+                auto& neigh = cloud->points[ni];
+                float dot = curr_pt.normal_x * neigh.normal_x +
+                            curr_pt.normal_y * neigh.normal_y +
+                            curr_pt.normal_z * neigh.normal_z;
+                if (dot < 0.0f) {
+                    neigh.normal_x *= -1.0f;
+                    neigh.normal_y *= -1.0f;
+                    neigh.normal_z *= -1.0f;
+                }
+
+                visited[ni] = true;
+                q.push(ni);
+            }
+        }
+    }
+};
+
+/**
+ * 网格后处理：简单合法化和退化三角形移除
+ */
+class MeshPostProcessor {
+public:
+    bool process(pcl::PolygonMesh& mesh) {
+        pcl::PointCloud<pcl::PointXYZ> cloud;
+        pcl::fromPCLPointCloud2(mesh.cloud, cloud);
+        std::vector<pcl::Vertices> cleaned;
+        cleaned.reserve(mesh.polygons.size());
+        for (const auto& poly : mesh.polygons) {
+            if (poly.vertices.size() != 3) continue;
+            const auto& a = cloud[poly.vertices[0]];
+            const auto& b = cloud[poly.vertices[1]];
+            const auto& c = cloud[poly.vertices[2]];
+            Eigen::Vector3f ab(b.x - a.x, b.y - a.y, b.z - a.z);
+            Eigen::Vector3f ac(c.x - a.x, c.y - a.y, c.z - a.z);
+            if (ab.cross(ac).norm() < 1e-6f) continue; // degenerate
+            cleaned.push_back(poly);
+        }
+        mesh.polygons.swap(cleaned);
         return true;
     }
 };
 
 /**
- * 简化的外壳重建类
- * 实现Stage 1的基本功能：UDF构建和表面提取
+ * 外壳重建器
+ * 组合UDF构建、图割优化和双重轮廓提取
  */
 class ShellReconstructor {
 public:
     struct Config {
-        float voxel_size = 0.01f;  // 1厘米体素
-        float truncation_distance = 0.03f;  // 3厘米截断距离
-        bool use_gaussian_filter = true;
+        recon::UDFConfig udf_config;
+        recon::GraphCutConfig graph_config;
+        recon::DualContouringConfig dc_config;
     };
 
-    ShellReconstructor(const Config& config) : config_(config) {}
+    explicit ShellReconstructor(const Config& config) : config_(config) {}
 
-    /**
-     * 从点云构建外壳网格
-     */
     bool reconstruct(PointNormalCloudT::Ptr input, pcl::PolygonMesh& output) {
         std::cout << "开始外壳重建..." << std::endl;
-        
-        // 初始化OpenVDB
         openvdb::initialize();
-        
-        // 1. 构建距离场
-        openvdb::FloatGrid::Ptr grid = buildDistanceField(input);
-        if (!grid) {
-            std::cerr << "距离场构建失败" << std::endl;
+
+        recon::UDFBuilder udf_builder(config_.udf_config);
+        openvdb::FloatGrid::Ptr udf_grid;
+        openvdb::FloatGrid::Ptr conf_grid;
+        if (!udf_builder.buildUDF(input, udf_grid, conf_grid)) {
+            std::cerr << "UDF构建失败" << std::endl;
             return false;
         }
-        
-        // 2. 提取网格
-        if (!extractMesh(grid, output)) {
-            std::cerr << "网格提取失败" << std::endl;
+
+        recon::GraphCutOptimizer optimizer(config_.graph_config);
+        openvdb::Int32Grid::Ptr label_grid;
+        if (!optimizer.optimize(udf_grid, conf_grid, input, label_grid)) {
+            std::cerr << "图割优化失败" << std::endl;
             return false;
         }
-        
+
+        recon::DualContouringExtractor extractor(config_.dc_config);
+        if (!extractor.extractSurface(udf_grid, label_grid, input, output)) {
+            std::cerr << "表面提取失败" << std::endl;
+            return false;
+        }
+
+        MeshPostProcessor post;
+        post.process(output);
+
         std::cout << "外壳重建完成，三角形数: " << output.polygons.size() << std::endl;
         return true;
     }
 
 private:
     Config config_;
-
-    openvdb::FloatGrid::Ptr buildDistanceField(PointNormalCloudT::Ptr cloud) {
-        using GridT = openvdb::FloatGrid;
-        GridT::Ptr grid = GridT::create(config_.truncation_distance);
-        grid->setTransform(openvdb::math::Transform::createLinearTransform(config_.voxel_size));
-        
-        // 创建点列表
-        struct PointList {
-            using PosType = openvdb::Vec3R;
-            using value_type = openvdb::Vec3R;
-            
-            std::vector<openvdb::Vec3R> pts;
-            double radius = 0.01;  // 使用double类型
-            
-            size_t size() const { return pts.size(); }
-            void getPos(size_t i, PosType& xyz) const { xyz = pts[i]; }
-            void getPosRad(size_t i, PosType& xyz, double& rad) const { 
-                xyz = pts[i]; 
-                rad = radius; 
-            }
-        } plist;
-        
-        for (const auto& p : cloud->points) {
-            plist.pts.emplace_back(p.x, p.y, p.z);
-        }
-        
-        // 光栅化为距离场
-        openvdb::tools::ParticlesToLevelSet<GridT> raster(*grid);
-        raster.setGrainSize(1);
-        raster.setRmin(config_.voxel_size * 0.5f);
-        raster.rasterizeSpheres(plist);
-        raster.finalize();
-        
-        // 可选的高斯滤波
-        if (config_.use_gaussian_filter) {
-            openvdb::tools::LevelSetFilter<GridT> filter(*grid);
-            filter.gaussian(1.0);
-        }
-        
-        return grid;
-    }
-
-    bool extractMesh(openvdb::FloatGrid::Ptr grid, pcl::PolygonMesh& mesh) {
-        // 使用OpenVDB的VolumeToMesh提取网格
-        std::vector<openvdb::Vec3s> points;
-        std::vector<openvdb::Vec3I> triangles;
-        std::vector<openvdb::Vec4I> quads;
-        
-        openvdb::tools::volumeToMesh(*grid, points, triangles, quads, 0.0);
-        
-        // 转换为PCL格式
-        pcl::PointCloud<pcl::PointXYZ> vertices;
-        vertices.reserve(points.size());
-        
-        for (const auto& p : points) {
-            vertices.push_back(pcl::PointXYZ(p.x(), p.y(), p.z()));
-        }
-        
-        // 设置顶点
-        pcl::toPCLPointCloud2(vertices, mesh.cloud);
-        
-        // 设置三角形
-        mesh.polygons.clear();
-        mesh.polygons.reserve(triangles.size() + quads.size() * 2);
-        
-        for (const auto& tri : triangles) {
-            pcl::Vertices vertices;
-            vertices.vertices = {static_cast<int>(tri.x()), 
-                               static_cast<int>(tri.y()), 
-                               static_cast<int>(tri.z())};
-            mesh.polygons.push_back(vertices);
-        }
-        
-        // 将四边形分解为三角形
-        for (const auto& quad : quads) {
-            pcl::Vertices tri1, tri2;
-            tri1.vertices = {static_cast<int>(quad.x()), 
-                           static_cast<int>(quad.y()), 
-                           static_cast<int>(quad.z())};
-            tri2.vertices = {static_cast<int>(quad.x()), 
-                           static_cast<int>(quad.z()), 
-                           static_cast<int>(quad.w())};
-            mesh.polygons.push_back(tri1);
-            mesh.polygons.push_back(tri2);
-        }
-        
-        return true;
-    }
 };
 
 /**
@@ -356,8 +468,28 @@ int main(int argc, char** argv) {
             std::cerr << "外壳重建失败" << std::endl;
             return -1;
         }
-        
-        // 4. 保存结果
+
+        // 4. 细节重建
+        recon::DetailReconstructionConfig detail_cfg;
+        recon::DetailReconstructor detail(detail_cfg);
+        pcl::PolygonMesh detail_mesh;
+        if (!detail.reconstructDetails(mesh, processed_cloud, detail_mesh)) {
+            std::cerr << "细节重建失败，继续使用外壳网格" << std::endl;
+        }
+
+        // 5. 融合与布尔运算
+        MeshFusionConfig fusion_cfg;
+        MeshFuser fuser(fusion_cfg);
+        pcl::PolygonMesh fused;
+        if (!detail_mesh.polygons.empty() && fuser.fuse(mesh, detail_mesh, processed_cloud, fused)) {
+            mesh.swap(fused);
+        } else {
+            std::cerr << "融合失败，使用简单拼接" << std::endl;
+            pcl::concatenatePolygonMeshes(mesh, detail_mesh, fused);
+            mesh.swap(fused);
+        }
+
+        // 6. 保存结果
         std::cout << "保存网格: " << output_file << std::endl;
         if (pcl::io::saveOBJFile(output_file, mesh) == -1) {
             std::cerr << "无法保存文件: " << output_file << std::endl;


### PR DESCRIPTION
## Summary
- add MeshFuser module to union shell and detail meshes with vertex welding, normal recomputation, and color transfer
- integrate fusion stage into pipeline after detail reconstruction
- clip detail geometry inside a dilated shell and fall back to alpha wrapping when boolean fusion fails

## Testing
- `CONDA_PREFIX=/usr pytest tests/test_pipeline.py::test_full_pipeline -q` *(fails: pkg-config cannot find openvdb)*

------
https://chatgpt.com/codex/tasks/task_e_689ab9499c9c83338cc51c26f051e0c3